### PR TITLE
feat: orchestrate specialists via delegation tool

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -111,8 +111,7 @@ describe('runNonInteractive', () => {
       'prompt-id-1',
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('Hello World');
-    expect(processStdoutSpy).toHaveBeenCalledWith('
-');
+    expect(processStdoutSpy).toHaveBeenCalledWith('\\n');
     expect(mockShutdownTelemetry).toHaveBeenCalled();
   });
 
@@ -145,8 +144,7 @@ describe('runNonInteractive', () => {
     const secondCallArgs = mockAgentsClient.sendMessage.mock.calls[1][0];
     expect(secondCallArgs.message).toEqual(toolResponse);
     expect(processStdoutSpy).toHaveBeenCalledWith('Final answer');
-    expect(processStdoutSpy).toHaveBeenCalledWith('
-');
+    expect(processStdoutSpy).toHaveBeenCalledWith('\\n');
   });
 
   it('should handle error during tool execution and send fallback message', async () => {
@@ -254,12 +252,9 @@ describe('runNonInteractive', () => {
     const rawInput = 'Summarize @file.txt';
     const processedParts: AgentContentFragment[] = [
       { text: 'Summarize @file.txt' },
-      { text: '
---- Content from referenced files ---
-' },
+      { text: '\n--- Content from referenced files ---\n' },
       { text: 'This is the content of the file.' },
-      { text: '
---- End of content ---' },
+      { text: '\n--- End of content ---' },
     ];
 
     mockHandleAtCommand.mockResolvedValue({

--- a/packages/cli/src/test-utils/render.tsx
+++ b/packages/cli/src/test-utils/render.tsx
@@ -7,12 +7,13 @@
 import { render } from 'ink-testing-library';
 import type React from 'react';
 import { KeypressProvider } from '../ui/contexts/KeypressContext.js';
+import { DesignSystemProvider } from '../ui/design-system/index.js';
 
 export const renderWithProviders = (
   component: React.ReactElement,
 ): ReturnType<typeof render> =>
   render(
     <KeypressProvider kittyProtocolEnabled={true}>
-      {component}
+      <DesignSystemProvider>{component}</DesignSystemProvider>
     </KeypressProvider>,
   );

--- a/packages/cli/src/test-utils/ripgrep-shim.ts
+++ b/packages/cli/src/test-utils/ripgrep-shim.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const rgPath = 'rg';

--- a/packages/cli/src/test-utils/signal-exit-shim.ts
+++ b/packages/cli/src/test-utils/signal-exit-shim.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export default function signalExitShim(handler: () => void) {
+  return () => {
+    handler();
+  };
+}

--- a/packages/cli/src/ui/components/CommandHintBar.tsx
+++ b/packages/cli/src/ui/components/CommandHintBar.tsx
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import {
+  useDesignSystem,
+  Surface,
+  SectionHeading,
+} from '../design-system/index.js';
+import type { KeyBinding } from '../../config/keyBindings.js';
+
+export interface CommandHint {
+  label: string;
+  commandText?: string;
+  bindings?: readonly KeyBinding[];
+}
+
+interface CommandHintBarProps {
+  hints: CommandHint[];
+  isCompact?: boolean;
+}
+
+const formatKey = (key: string | undefined): string => {
+  if (!key) {
+    return '';
+  }
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+  return key.replace(/_/g, ' ').replace(/\b\w/g, (match) => match.toUpperCase());
+};
+
+const pickBinding = (bindings: readonly KeyBinding[] | undefined): KeyBinding | undefined => {
+  if (!bindings || bindings.length === 0) {
+    return undefined;
+  }
+  const prioritized = bindings.find((binding) => binding.ctrl || binding.command || binding.shift);
+  return prioritized ?? bindings[0];
+};
+
+const formatBinding = (binding: KeyBinding | undefined): string | undefined => {
+  if (!binding) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  if (binding.ctrl) {
+    parts.push('Ctrl');
+  }
+  if (binding.shift) {
+    parts.push('Shift');
+  }
+  if (binding.command) {
+    parts.push('Cmd');
+  }
+  const key = formatKey(binding.key);
+  if (key) {
+    parts.push(key);
+  }
+  return parts.join('+') || undefined;
+};
+
+export const CommandHintBar: React.FC<CommandHintBarProps> = ({
+  hints,
+  isCompact = false,
+}) => {
+  const design = useDesignSystem();
+
+  if (!hints.length) {
+    return null;
+  }
+
+  return (
+    <Surface
+      width="100%"
+      marginTop={1}
+      paddingY={0}
+      borderTone="accent"
+    >
+      <SectionHeading icon="⌨️" text="Hints" />
+      <Box flexDirection={isCompact ? 'column' : 'row'}>
+        {hints.map((hint, index) => {
+          const binding = formatBinding(pickBinding(hint.bindings));
+          const value = hint.commandText ?? binding;
+          if (!value) {
+            return null;
+          }
+          return (
+            <Box
+              key={`${hint.label}-${value}`}
+              marginRight={
+                !isCompact && index < hints.length - 1
+                  ? design.spacing.sm
+                  : design.spacing.none
+              }
+              marginBottom={isCompact && index < hints.length - 1 ? 1 : 0}
+            >
+              <Text color={design.colors.text.muted}>{hint.label}: </Text>
+              <Text color={design.colors.text.link}>{value}</Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Surface>
+  );
+};

--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -4,41 +4,46 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render } from 'ink-testing-library';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Header } from './Header.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
 import { longAsciiLogo } from './AsciiArt.js';
+import { renderWithProviders } from '../../test-utils/render.js';
 
 vi.mock('../hooks/useTerminalSize.js');
 
 describe('<Header />', () => {
-  beforeEach(() => {});
 
   it('renders the long logo on a wide terminal', () => {
     vi.spyOn(useTerminalSize, 'useTerminalSize').mockReturnValue({
       columns: 120,
       rows: 20,
     });
-    const { lastFrame } = render(<Header version="1.0.0" nightly={false} />);
+    const { lastFrame } = renderWithProviders(
+      <Header version="1.0.0" nightly={false} />,
+    );
     expect(lastFrame()).toContain(longAsciiLogo);
   });
 
   it('renders custom ASCII art when provided', () => {
     const customArt = 'CUSTOM ART';
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithProviders(
       <Header version="1.0.0" nightly={false} customAsciiArt={customArt} />,
     );
     expect(lastFrame()).toContain(customArt);
   });
 
   it('displays the version number when nightly is true', () => {
-    const { lastFrame } = render(<Header version="1.0.0" nightly={true} />);
+    const { lastFrame } = renderWithProviders(
+      <Header version="1.0.0" nightly={true} />,
+    );
     expect(lastFrame()).toContain('v1.0.0');
   });
 
   it('does not display the version number when nightly is false', () => {
-    const { lastFrame } = render(<Header version="1.0.0" nightly={false} />);
+    const { lastFrame } = renderWithProviders(
+      <Header version="1.0.0" nightly={false} />,
+    );
     expect(lastFrame()).not.toContain('v1.0.0');
   });
 });

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -7,7 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import Gradient from 'ink-gradient';
-import { Colors } from '../colors.js';
+import { useDesignSystem } from '../design-system/index.js';
 import { shortAsciiLogo, longAsciiLogo, tinyAsciiLogo } from './AsciiArt.js';
 import { getAsciiArtWidth } from '../utils/textUtils.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
@@ -23,6 +23,7 @@ export const Header: React.FC<HeaderProps> = ({
   version,
   nightly,
 }) => {
+  const { colors } = useDesignSystem();
   const { columns: terminalWidth } = useTerminalSize();
   let displayTitle;
   const widthOfLongLogo = getAsciiArtWidth(longAsciiLogo);
@@ -41,7 +42,10 @@ export const Header: React.FC<HeaderProps> = ({
   const artWidth = getAsciiArtWidth(displayTitle);
 
   // Use theme-appropriate gradient colors for the 3D effect
-  const gradientColors = Colors.GradientColors || [Colors.AccentBlue, Colors.AccentPurple, Colors.AccentCyan];
+  const gradientColors =
+    colors.surface.gradient.length > 1
+      ? colors.surface.gradient
+      : undefined;
   
   return (
     <Box
@@ -50,21 +54,21 @@ export const Header: React.FC<HeaderProps> = ({
       flexShrink={0}
       flexDirection="column"
     >
-      {Colors.GradientColors ? (
+      {gradientColors ? (
         <Gradient colors={gradientColors}>
           <Text>{displayTitle}</Text>
         </Gradient>
       ) : (
-        <Text color={Colors.Primary}>{displayTitle}</Text>
+        <Text color={colors.text.accent}>{displayTitle}</Text>
       )}
       {nightly && (
         <Box width="100%" flexDirection="row" justifyContent="flex-end">
-          {Colors.GradientColors ? (
+          {gradientColors ? (
             <Gradient colors={gradientColors}>
               <Text>v{version}</Text>
             </Gradient>
           ) : (
-            <Text color={Colors.AccentPurple}>v{version}</Text>
+            <Text color={colors.text.link}>v{version}</Text>
           )}
         </Box>
       )}

--- a/packages/cli/src/ui/components/HistoryActivityRail.test.tsx
+++ b/packages/cli/src/ui/components/HistoryActivityRail.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { HistoryItem } from '../types.js';
+import { ToolCallStatus } from '../types.js';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { HistoryActivityRail } from './HistoryActivityRail.js';
+
+const baseHistory: HistoryItem[] = [
+  { id: 1, type: 'user', text: 'Open the project README.' },
+  { id: 2, type: 'gemini', text: 'Sure thing! Here is what I found.' },
+  {
+    id: 3,
+    type: 'tool_group',
+    tools: [
+      {
+        callId: 'call-1',
+        name: 'local_shell',
+        description: 'Run a shell command',
+        status: ToolCallStatus.Success,
+        confirmationDetails: undefined,
+        resultDisplay: undefined,
+      },
+    ],
+  },
+];
+
+describe('<HistoryActivityRail />', () => {
+  it('renders recent activity entries with icons', () => {
+    const { lastFrame } = renderWithProviders(
+      <HistoryActivityRail history={baseHistory} maxItems={3} />,
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain('🗂');
+    expect(frame).toContain('🙋 User');
+    expect(frame).toContain('🤖 Gemini');
+    expect(frame).toContain('🛠️ Tools');
+  });
+
+  it('includes pending items at the front of the rail', () => {
+    const { lastFrame } = renderWithProviders(
+      <HistoryActivityRail
+        history={baseHistory.slice(0, 1)}
+        pendingItems={baseHistory.slice(1).map(({ id, ...rest }) => rest)}
+        maxItems={2}
+      />,
+    );
+
+    const frame = lastFrame();
+    expect(frame?.indexOf('⏳ Pending')).toBeLessThan(
+      frame?.indexOf('🙋 User') ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it('renders nothing when history and pending items are empty', () => {
+    const { lastFrame } = renderWithProviders(
+      <HistoryActivityRail history={[]} pendingItems={[]} />,
+    );
+
+    expect(lastFrame()).toBe('');
+  });
+});

--- a/packages/cli/src/ui/components/HistoryActivityRail.tsx
+++ b/packages/cli/src/ui/components/HistoryActivityRail.tsx
@@ -1,0 +1,263 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import {
+  Surface,
+  SectionHeading,
+  useDesignSystem,
+} from '../design-system/index.js';
+import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
+
+interface HistoryActivityRailProps {
+  readonly history: readonly HistoryItem[];
+  readonly pendingItems?: readonly HistoryItemWithoutId[];
+  readonly maxItems?: number;
+  readonly isCompact?: boolean;
+}
+
+type ActivityTone =
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'muted';
+
+interface ActivityDescriptor {
+  readonly icon: string;
+  readonly label: string;
+  readonly summary?: string;
+  readonly tone: ActivityTone;
+}
+
+const truncate = (input: string | undefined, maxLength: number): string | undefined => {
+  if (!input) {
+    return undefined;
+  }
+  const normalized = input.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1)}…`;
+};
+
+const summarizeToolGroup = (item: HistoryItemWithoutId & { type: 'tool_group' }): string => {
+  if (!item.tools.length) {
+    return 'No tools invoked';
+  }
+  const names = item.tools.map((tool) => tool.name);
+  const preview = names.slice(0, 3).join(', ');
+  return names.length > 3 ? `${preview}, …` : preview;
+};
+
+const summarizeMultiAgent = (
+  item: HistoryItemWithoutId & { type: 'multi_agent_status' },
+): string => {
+  const statusLabel = item.selection.status;
+  const agents = item.selection.selectedAgents;
+  const agentPreview = agents
+    .slice(0, 2)
+    .map((agent) => agent.name)
+    .join(', ');
+  if (!agentPreview) {
+    return statusLabel;
+  }
+  return agents.length > 2
+    ? `${statusLabel} · ${agentPreview}, …`
+    : `${statusLabel} · ${agentPreview}`;
+};
+
+const describeItem = (item: HistoryItemWithoutId): ActivityDescriptor => {
+  switch (item.type) {
+    case 'user':
+    case 'user_shell':
+      return {
+        icon: '🙋',
+        label: 'User',
+        summary: truncate(item.text, 64),
+        tone: 'accent',
+      };
+    case 'gemini':
+    case 'gemini_content':
+      return {
+        icon: '🤖',
+        label: 'Gemini',
+        summary: truncate(item.text, 64),
+        tone: 'info',
+      };
+    case 'tool_group':
+      return {
+        icon: '🛠️',
+        label: 'Tools',
+        summary: summarizeToolGroup(item),
+        tone: 'info',
+      };
+    case 'info':
+      return {
+        icon: 'ℹ️',
+        label: 'Info',
+        summary: truncate(item.text, 64),
+        tone: 'muted',
+      };
+    case 'error':
+      return {
+        icon: '⚠️',
+        label: 'Error',
+        summary: truncate(item.text, 64),
+        tone: 'danger',
+      };
+    case 'multi_agent_status':
+      return {
+        icon: '🤝',
+        label: 'Agents',
+        summary: summarizeMultiAgent(item),
+        tone: 'accent',
+      };
+    case 'stats':
+    case 'model_stats':
+    case 'tool_stats':
+      return {
+        icon: '📊',
+        label: 'Stats',
+        summary: truncate(item.text, 64),
+        tone: 'muted',
+      };
+    case 'compression':
+      return {
+        icon: '🗜️',
+        label: 'Compression',
+        summary: item.compression.isPending
+          ? 'Pending compression'
+          : 'Compression complete',
+        tone: item.compression.isPending ? 'info' : 'muted',
+      };
+    case 'help':
+      return {
+        icon: '❓',
+        label: 'Help',
+        summary: item.timestamp.toLocaleTimeString(),
+        tone: 'muted',
+      };
+    case 'about':
+      return {
+        icon: '🧭',
+        label: 'About',
+        summary: item.cliVersion,
+        tone: 'muted',
+      };
+    case 'quit':
+      return {
+        icon: '🏁',
+        label: 'Session',
+        summary: item.duration,
+        tone: 'muted',
+      };
+    default:
+      return {
+        icon: '…',
+        label: item.type,
+        summary: truncate(item.text, 64),
+        tone: 'muted',
+      };
+  }
+};
+
+const toneToColor = (
+  tone: ActivityTone,
+  design: ReturnType<typeof useDesignSystem>,
+): string => {
+  switch (tone) {
+    case 'accent':
+      return design.colors.text.accent;
+    case 'info':
+      return design.colors.status.info;
+    case 'success':
+      return design.colors.status.success;
+    case 'warning':
+      return design.colors.status.warning;
+    case 'danger':
+      return design.colors.status.error;
+    case 'muted':
+    default:
+      return design.colors.text.secondary;
+  }
+};
+
+export const HistoryActivityRail: React.FC<HistoryActivityRailProps> = ({
+  history,
+  pendingItems = [],
+  maxItems = 5,
+  isCompact = false,
+}) => {
+  const design = useDesignSystem();
+  const pendingDescriptors = pendingItems.slice(0, 2).map((item) => {
+    const base = describeItem(item);
+    const detail = base.summary ? `${base.label}: ${base.summary}` : base.label;
+    return {
+      icon: '⏳',
+      label: 'Pending',
+      summary: truncate(`Awaiting ${detail}`, 64),
+      tone: 'info' as ActivityTone,
+    };
+  });
+
+  const historyDescriptors = history
+    .slice(-maxItems)
+    .reverse()
+    .map((item) => describeItem(item));
+
+  const descriptors = [...pendingDescriptors, ...historyDescriptors].slice(
+    0,
+    maxItems,
+  );
+
+  if (!descriptors.length) {
+    return null;
+  }
+
+  return (
+    <Surface
+      variant="base"
+      borderTone="accent"
+      flexDirection="column"
+      width="100%"
+      marginBottom={1}
+    >
+      <SectionHeading icon="🗂" text="Recent Activity" />
+      <Box
+        flexDirection={isCompact ? 'column' : 'row'}
+        flexWrap="wrap"
+        marginTop={1}
+      >
+        {descriptors.map((descriptor, index) => (
+          <Box
+            key={`${descriptor.label}-${index}`}
+            flexDirection="column"
+            flexGrow={1}
+            marginRight={
+              !isCompact && index < descriptors.length - 1
+                ? design.spacing.md
+                : design.spacing.none
+            }
+            marginBottom={design.spacing.xs}
+            width={isCompact ? undefined : 28}
+          >
+            <Text color={toneToColor(descriptor.tone, design)}>
+              {descriptor.icon} {descriptor.label}
+            </Text>
+            {descriptor.summary && (
+              <Text color={design.colors.text.muted} wrap="truncate">
+                {descriptor.summary}
+              </Text>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Surface>
+  );
+};

--- a/packages/cli/src/ui/components/SessionStatusBar.tsx
+++ b/packages/cli/src/ui/components/SessionStatusBar.tsx
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { Surface, useDesignSystem } from '../design-system/index.js';
+import { StreamingState } from '../types.js';
+
+type Tone =
+  | 'default'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'muted';
+
+interface SessionStatusBarProps {
+  streamingState: StreamingState;
+  queueLength: number;
+  pendingToolCount: number;
+  activeToolNames: string[];
+  totalHistoryItems: number;
+  model: string;
+  isTrustedWorkspace: boolean;
+  userTierLabel: string;
+  shellModeActive: boolean;
+  isCompact: boolean;
+}
+
+interface Segment {
+  label: string;
+  value: string;
+  tone: Tone;
+}
+
+function toneToColor(tone: Tone, palette: ReturnType<typeof useDesignSystem>['colors']): string {
+  switch (tone) {
+    case 'accent':
+      return palette.text.accent;
+    case 'info':
+      return palette.status.info;
+    case 'success':
+      return palette.status.success;
+    case 'warning':
+      return palette.status.warning;
+    case 'danger':
+      return palette.status.error;
+    case 'muted':
+      return palette.text.secondary;
+    case 'default':
+    default:
+      return palette.text.primary;
+  }
+}
+
+function describeStreamingState(state: StreamingState): { label: string; tone: Tone } {
+  switch (state) {
+    case StreamingState.Responding:
+      return { label: 'Responding', tone: 'accent' };
+    case StreamingState.WaitingForConfirmation:
+      return { label: 'Waiting for confirmation', tone: 'warning' };
+    case StreamingState.Idle:
+    default:
+      return { label: 'Idle', tone: 'muted' };
+  }
+}
+
+function formatToolSummary(
+  pendingToolCount: number,
+  activeToolNames: string[],
+): string {
+  if (pendingToolCount === 0) {
+    return 'Idle';
+  }
+
+  const visibleTools = activeToolNames.slice(0, 2);
+  const suffix =
+    visibleTools.length > 0
+      ? ` (${visibleTools.join(', ')}${
+          activeToolNames.length > visibleTools.length ? '…' : ''
+        })`
+      : '';
+  return `${pendingToolCount} running${suffix}`;
+}
+
+const formatModeLabel = (mode: string): string => {
+  switch (mode) {
+    case 'light':
+      return 'Light';
+    case 'monochrome':
+      return 'Mono';
+    case 'dark':
+    default:
+      return 'Dark';
+  }
+};
+
+export const SessionStatusBar: React.FC<SessionStatusBarProps> = ({
+  streamingState,
+  queueLength,
+  pendingToolCount,
+  activeToolNames,
+  totalHistoryItems,
+  model,
+  isTrustedWorkspace,
+  userTierLabel,
+  shellModeActive,
+  isCompact,
+}) => {
+  const design = useDesignSystem();
+  const streamDescriptor = describeStreamingState(streamingState);
+  const segments: Segment[] = [
+    {
+      label: 'Theme',
+      value: `${design.meta.themeName} · ${formatModeLabel(design.mode)}`,
+      tone: 'accent',
+    },
+    {
+      label: 'Model',
+      value: model,
+      tone: 'info',
+    },
+    {
+      label: 'Stream',
+      value: streamDescriptor.label,
+      tone: streamDescriptor.tone,
+    },
+    {
+      label: 'Queue',
+      value: queueLength > 0 ? `${queueLength} pending` : 'Empty',
+      tone: queueLength > 0 ? 'warning' : 'muted',
+    },
+    {
+      label: 'Tools',
+      value: formatToolSummary(pendingToolCount, activeToolNames),
+      tone: pendingToolCount > 0 ? 'info' : 'muted',
+    },
+    {
+      label: 'History',
+      value: `${totalHistoryItems}`,
+      tone: 'muted',
+    },
+    {
+      label: 'Tier',
+      value: userTierLabel,
+      tone:
+        userTierLabel.toLowerCase().includes('standard') ||
+        userTierLabel.toLowerCase().includes('legacy')
+          ? 'success'
+          : 'muted',
+    },
+    {
+      label: 'Workspace',
+      value: isTrustedWorkspace ? 'Trusted' : 'Untrusted',
+      tone: isTrustedWorkspace ? 'success' : 'warning',
+    },
+    {
+      label: 'Shell',
+      value: shellModeActive ? 'On' : 'Off',
+      tone: shellModeActive ? 'warning' : 'muted',
+    },
+  ];
+
+  return (
+    <Surface
+      width="100%"
+      flexDirection={isCompact ? 'column' : 'row'}
+      variant="sunken"
+      paddingY={isCompact ? 0 : 0}
+      marginBottom={1}
+    >
+      {segments.map((segment, index) => (
+        <Box
+          key={`${segment.label}-${index}`}
+          marginRight={
+            !isCompact && index < segments.length - 1
+              ? design.spacing.sm
+              : design.spacing.none
+          }
+          marginBottom={isCompact && index < segments.length - 1 ? 1 : 0}
+        >
+          <Text color={design.colors.text.muted}>{segment.label}:</Text>
+          <Text> </Text>
+          <Text color={toneToColor(segment.tone, design.colors)}>
+            {segment.value}
+          </Text>
+        </Box>
+      ))}
+    </Surface>
+  );
+};

--- a/packages/cli/src/ui/design-system/DesignSystemProvider.tsx
+++ b/packages/cli/src/ui/design-system/DesignSystemProvider.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+} from 'react';
+import { themeManager } from '../themes/theme-manager.js';
+import type { SemanticColors } from '../themes/semantic-tokens.js';
+import type { ThemeType } from '../themes/theme.js';
+import {
+  createDesignTokens,
+  type DesignSystemSnapshot,
+  type DesignTokens,
+} from './tokens.js';
+
+interface ThemeSnapshot {
+  readonly name: string;
+  readonly type: ThemeType;
+  readonly semantics: SemanticColors;
+}
+
+const DesignSystemContext = createContext<DesignTokens | null>(null);
+
+const getSnapshot = (): ThemeSnapshot => {
+  const activeTheme = themeManager.getActiveTheme();
+  return {
+    name: activeTheme.name,
+    type: activeTheme.type,
+    semantics: themeManager.getSemanticColors(),
+  };
+};
+
+const subscribe = (listener: () => void) => themeManager.subscribe(listener);
+
+export const DesignSystemProvider = ({
+  children,
+}: PropsWithChildren<unknown>) => {
+  const snapshot = useSyncExternalStore<ThemeSnapshot>(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
+
+  const tokens = useMemo<DesignTokens>(() => {
+    const designSnapshot: DesignSystemSnapshot = {
+      name: snapshot.name,
+      type: snapshot.type,
+      semantics: snapshot.semantics,
+    };
+    return createDesignTokens(designSnapshot);
+  }, [snapshot]);
+
+  return (
+    <DesignSystemContext.Provider value={tokens}>
+      {children}
+    </DesignSystemContext.Provider>
+  );
+};
+
+export const useDesignSystem = (): DesignTokens => {
+  const context = useContext(DesignSystemContext);
+  if (!context) {
+    throw new Error('useDesignSystem must be used within a DesignSystemProvider');
+  }
+  return context;
+};

--- a/packages/cli/src/ui/design-system/components.tsx
+++ b/packages/cli/src/ui/design-system/components.tsx
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PropsWithChildren } from 'react';
+import { Box, type BoxProps, Text } from 'ink';
+import { useDesignSystem } from './index.js';
+
+export type SurfaceVariant = 'base' | 'elevated' | 'sunken' | 'transparent';
+export type SurfaceBorderTone =
+  | 'none'
+  | 'default'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+export interface SurfaceProps
+  extends PropsWithChildren<
+    BoxProps & {
+      variant?: SurfaceVariant;
+      borderTone?: SurfaceBorderTone;
+    }
+  > {}
+
+const resolveBackgroundColor = (
+  variant: SurfaceVariant,
+  baseColors: ReturnType<typeof useDesignSystem>['colors']['surface'],
+): string | undefined => {
+  switch (variant) {
+    case 'base':
+      return baseColors.base;
+    case 'sunken':
+      return baseColors.sunken;
+    case 'elevated':
+      return baseColors.elevated;
+    case 'transparent':
+    default:
+      return undefined;
+  }
+};
+
+const resolveBorderColor = (
+  tone: SurfaceBorderTone,
+  design: ReturnType<typeof useDesignSystem>,
+): string | undefined => {
+  switch (tone) {
+    case 'none':
+      return undefined;
+    case 'accent':
+      return design.colors.text.accent;
+    case 'info':
+      return design.colors.status.info;
+    case 'success':
+      return design.colors.status.success;
+    case 'warning':
+      return design.colors.status.warning;
+    case 'danger':
+      return design.colors.status.error;
+    case 'default':
+    default:
+      return design.colors.surface.border;
+  }
+};
+
+export const Surface = ({
+  variant = 'elevated',
+  borderTone = 'default',
+  children,
+  borderStyle,
+  borderColor,
+  backgroundColor,
+  paddingX,
+  paddingY,
+  ...rest
+}: SurfaceProps) => {
+  const design = useDesignSystem();
+  const resolvedBackgroundColor =
+    backgroundColor ?? resolveBackgroundColor(variant, design.colors.surface);
+  const resolvedBorderColor =
+    borderColor ?? resolveBorderColor(borderTone, design);
+  const resolvedBorderStyle =
+    borderTone === 'none' && borderStyle === undefined
+      ? undefined
+      : borderStyle ?? 'round';
+
+  return (
+    <Box
+      borderStyle={resolvedBorderStyle}
+      borderColor={resolvedBorderColor}
+      backgroundColor={resolvedBackgroundColor}
+      paddingX={paddingX ?? design.spacing.sm}
+      paddingY={paddingY ?? 0}
+      {...rest}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export type SectionHeadingTone =
+  | 'accent'
+  | 'muted'
+  | 'default'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+export interface SectionHeadingProps {
+  readonly icon?: string;
+  readonly text: string;
+  readonly tone?: SectionHeadingTone;
+}
+
+const resolveHeadingColor = (
+  tone: SectionHeadingTone,
+  design: ReturnType<typeof useDesignSystem>,
+): string => {
+  switch (tone) {
+    case 'muted':
+      return design.colors.text.muted;
+    case 'info':
+      return design.colors.status.info;
+    case 'success':
+      return design.colors.status.success;
+    case 'warning':
+      return design.colors.status.warning;
+    case 'danger':
+      return design.colors.status.error;
+    case 'accent':
+      return design.colors.text.accent;
+    case 'default':
+    default:
+      return design.colors.text.primary;
+  }
+};
+
+export const SectionHeading = ({
+  icon,
+  text,
+  tone = 'accent',
+}: SectionHeadingProps) => {
+  const design = useDesignSystem();
+  const color = resolveHeadingColor(tone, design);
+  const content =
+    design.typography.label.transform === 'uppercase'
+      ? text.toUpperCase()
+      : text;
+
+  return (
+    <Text color={color}>
+      {icon ? `${icon} ` : ''}
+      {content}
+    </Text>
+  );
+};

--- a/packages/cli/src/ui/design-system/index.ts
+++ b/packages/cli/src/ui/design-system/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  DesignSystemProvider,
+  useDesignSystem,
+} from './DesignSystemProvider.js';
+export type { DesignTokens, DesignMode } from './tokens.js';
+export {
+  Surface,
+  type SurfaceProps,
+  type SurfaceVariant,
+  type SurfaceBorderTone,
+  SectionHeading,
+  type SectionHeadingProps,
+  type SectionHeadingTone,
+} from './components.js';

--- a/packages/cli/src/ui/design-system/tokens.test.ts
+++ b/packages/cli/src/ui/design-system/tokens.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  darkSemanticColors,
+  lightSemanticColors,
+} from '../themes/semantic-tokens.js';
+import { createDesignTokens } from './tokens.js';
+
+describe('createDesignTokens', () => {
+  it('produces consistent metadata and gradients for dark themes', () => {
+    const tokens = createDesignTokens({
+      name: 'Dark Test',
+      type: 'dark',
+      semantics: darkSemanticColors,
+    });
+
+    expect(tokens.mode).toBe('dark');
+    expect(tokens.meta.themeName).toBe('Dark Test');
+    expect(tokens.colors.surface.gradient.length).toBeGreaterThanOrEqual(2);
+    expect(tokens.colors.surface.elevated).not.toBe(tokens.colors.surface.base);
+  });
+
+  it('lightens and darkens surfaces for light themes', () => {
+    const tokens = createDesignTokens({
+      name: 'Light Test',
+      type: 'light',
+      semantics: lightSemanticColors,
+    });
+
+    expect(tokens.mode).toBe('light');
+    expect(tokens.colors.surface.elevated).not.toBe(tokens.colors.surface.base);
+    expect(tokens.colors.surface.sunken).not.toBe(tokens.colors.surface.base);
+    expect(tokens.colors.text.muted).not.toBe(tokens.colors.text.secondary);
+  });
+});

--- a/packages/cli/src/ui/design-system/tokens.ts
+++ b/packages/cli/src/ui/design-system/tokens.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Colors } from '../colors.js';
+import type { SemanticColors } from '../themes/semantic-tokens.js';
+import type { ThemeType } from '../themes/theme.js';
+import { CSS_NAME_TO_HEX_MAP } from '../themes/color-utils.js';
+
+const INK_BASE_COLOR_MAP: Record<string, string> = {
+  black: '#000000',
+  red: '#ff0000',
+  green: '#00ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  cyan: '#00ffff',
+  magenta: '#ff00ff',
+  white: '#ffffff',
+  gray: '#808080',
+  grey: '#808080',
+  blackbright: '#4d4d4d',
+  redbright: '#ff4d4d',
+  greenbright: '#4dff4d',
+  yellowbright: '#ffff4d',
+  bluebright: '#4d4dff',
+  cyanbright: '#4dffff',
+  magentabright: '#ff4dff',
+  whitebright: '#ffffff',
+};
+
+function normalizeHex(color: string): string | null {
+  if (!color) {
+    return null;
+  }
+  const trimmed = color.trim();
+  const lower = trimmed.toLowerCase();
+
+  if (lower.startsWith('#')) {
+    if (/^#[0-9a-f]{3}$/i.test(lower)) {
+      const r = lower[1];
+      const g = lower[2];
+      const b = lower[3];
+      return `#${r}${r}${g}${g}${b}${b}`;
+    }
+    if (/^#[0-9a-f]{6}$/i.test(lower)) {
+      return lower;
+    }
+    return null;
+  }
+
+  if (CSS_NAME_TO_HEX_MAP[lower]) {
+    return CSS_NAME_TO_HEX_MAP[lower];
+  }
+
+  if (INK_BASE_COLOR_MAP[lower]) {
+    return INK_BASE_COLOR_MAP[lower];
+  }
+
+  return null;
+}
+
+function channelToHex(channel: number): string {
+  const clamped = Math.max(0, Math.min(255, Math.round(channel)));
+  return clamped.toString(16).padStart(2, '0');
+}
+
+function adjustColor(color: string, amount: number): string {
+  const hex = normalizeHex(color);
+  if (!hex) {
+    return color;
+  }
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  const adjustChannel = (channel: number) => {
+    if (amount >= 0) {
+      return channel + (255 - channel) * amount;
+    }
+    return channel * (1 + amount);
+  };
+
+  const nextR = adjustChannel(r);
+  const nextG = adjustChannel(g);
+  const nextB = adjustChannel(b);
+
+  return `#${channelToHex(nextR)}${channelToHex(nextG)}${channelToHex(nextB)}`;
+}
+
+export type DesignMode = 'dark' | 'light' | 'monochrome';
+
+export interface DesignTokens {
+  readonly mode: DesignMode;
+  readonly meta: {
+    readonly themeName: string;
+  };
+  readonly colors: {
+    readonly surface: {
+      readonly base: string;
+      readonly elevated: string;
+      readonly sunken: string;
+      readonly border: string;
+      readonly focus: string;
+      readonly gradient: string[];
+    };
+    readonly text: {
+      readonly primary: string;
+      readonly secondary: string;
+      readonly accent: string;
+      readonly link: string;
+      readonly muted: string;
+    };
+    readonly status: {
+      readonly success: string;
+      readonly warning: string;
+      readonly error: string;
+      readonly info: string;
+    };
+  };
+  readonly spacing: {
+    readonly none: 0;
+    readonly xs: 1;
+    readonly sm: 2;
+    readonly md: 3;
+    readonly lg: 4;
+    readonly xl: 6;
+  };
+  readonly shape: {
+    readonly radius: {
+      readonly sm: number;
+      readonly md: number;
+      readonly lg: number;
+    };
+  };
+  readonly typography: {
+    readonly label: {
+      readonly transform: 'uppercase' | 'none';
+      readonly letterSpacing: number;
+    };
+  };
+}
+
+export interface DesignSystemSnapshot {
+  readonly name: string;
+  readonly type: ThemeType;
+  readonly semantics: SemanticColors;
+}
+
+export function createDesignTokens({
+  name,
+  type,
+  semantics,
+}: DesignSystemSnapshot): DesignTokens {
+  const mode: DesignMode =
+    type === 'light' ? 'light' : type === 'ansi' ? 'monochrome' : 'dark';
+
+  const baseSurface = semantics.background.primary;
+  const elevatedSurface =
+    mode === 'light'
+      ? adjustColor(baseSurface, 0.05)
+      : adjustColor(baseSurface, 0.12);
+  const sunkenSurface =
+    mode === 'light'
+      ? adjustColor(baseSurface, -0.12)
+      : adjustColor(baseSurface, -0.16);
+
+  const gradientCandidates =
+    semantics.ui.gradient ?? Colors.GradientColors ?? [
+      Colors.AccentBlue,
+      Colors.AccentPurple,
+      Colors.AccentCyan,
+    ];
+  const gradient = gradientCandidates.filter(Boolean);
+  if (gradient.length < 2) {
+    gradient.push(Colors.AccentBlue, Colors.AccentPurple);
+  }
+
+  return {
+    mode,
+    meta: {
+      themeName: name,
+    },
+    colors: {
+      surface: {
+        base: baseSurface,
+        elevated: elevatedSurface,
+        sunken: sunkenSurface,
+        border: semantics.border.default,
+        focus: semantics.border.focused,
+        gradient,
+      },
+      text: {
+        primary: semantics.text.primary,
+        secondary: semantics.text.secondary,
+        accent: semantics.text.accent,
+        link: semantics.text.link,
+        muted:
+          mode === 'light'
+            ? adjustColor(semantics.text.secondary, -0.1)
+            : adjustColor(semantics.text.secondary, 0.15),
+      },
+      status: {
+        success: semantics.status.success,
+        warning: semantics.status.warning,
+        error: semantics.status.error,
+        info: Colors.AccentCyan,
+      },
+    },
+    spacing: {
+      none: 0,
+      xs: 1,
+      sm: 2,
+      md: 3,
+      lg: 4,
+      xl: 6,
+    },
+    shape: {
+      radius: {
+        sm: 0,
+        md: 1,
+        lg: 2,
+      },
+    },
+    typography: {
+      label: {
+        transform: 'uppercase',
+        letterSpacing: 0.08,
+      },
+    },
+  } as const;
+}

--- a/packages/cli/src/ui/themes/theme-manager.test.ts
+++ b/packages/cli/src/ui/themes/theme-manager.test.ts
@@ -95,6 +95,20 @@ describe('ThemeManager', () => {
     expect(themeManager.getTheme('MyCustomTheme')).toBeDefined();
   });
 
+  it('notifies subscribers when the active theme changes', () => {
+    const listener = vi.fn();
+    const unsubscribe = themeManager.subscribe(listener);
+
+    themeManager.setActiveTheme('Ayu');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    listener.mockClear();
+    unsubscribe();
+
+    themeManager.setActiveTheme(DEFAULT_THEME.name);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('should fall back to default theme if active theme is invalid', () => {
     (themeManager as unknown as { activeTheme: unknown }).activeTheme = {
       name: 'NonExistent',

--- a/packages/cli/src/ui/themes/theme-manager.ts
+++ b/packages/cli/src/ui/themes/theme-manager.ts
@@ -39,6 +39,7 @@ class ThemeManager {
   private readonly availableThemes: Theme[];
   private activeTheme: Theme;
   private customThemes: Map<string, Theme> = new Map();
+  private listeners: Set<() => void> = new Set();
 
   constructor() {
     this.availableThemes = [
@@ -104,6 +105,8 @@ class ThemeManager {
     ) {
       this.activeTheme = this.customThemes.get(this.activeTheme.name)!;
     }
+
+    this.emitChange();
   }
 
   /**
@@ -117,6 +120,7 @@ class ThemeManager {
       return false;
     }
     this.activeTheme = theme;
+    this.emitChange();
     return true;
   }
 
@@ -319,6 +323,23 @@ class ThemeManager {
     // If it's not a built-in, not in cache, and not a valid file path,
     // it's not a valid theme.
     return undefined;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emitChange(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (error) {
+        console.error('ThemeManager listener threw an error', error);
+      }
+    }
   }
 }
 

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -6,13 +6,29 @@
 
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const resolveFromConfig = (...segments: string[]) => resolve(__dirname, ...segments);
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'signal-exit': resolveFromConfig('./src/test-utils/signal-exit-shim.ts'),
+      '@ouroboros/ouroboros-code-core': resolveFromConfig('../core/src/index.ts'),
+      '@lvce-editor/ripgrep': resolveFromConfig('./src/test-utils/ripgrep-shim.ts'),
+    },
+  },
   test: {
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', 'config.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'jsdom',
     globals: true,
+    deps: {
+      inline: ['ink-testing-library', 'ink', 'signal-exit'],
+    },
     reporters: ['default', 'junit'],
     silent: true,
     outputFile: {

--- a/packages/core/src/agents/personas.ts
+++ b/packages/core/src/agents/personas.ts
@@ -30,6 +30,8 @@ import { MemoryTool } from '../tools/memoryTool.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
 import { WebSearchTool } from '../tools/web-search.js';
 import { UpdatePlanTool } from '../tools/update-plan.js';
+import { LocalShellTool } from '../tools/local-shell.js';
+import { ImageGenerationTool } from '../tools/image-generation.js';
 
 // ES modules equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -45,10 +47,12 @@ const CORE_TOOL_SUGGESTIONS = [
   EditTool?.Name ?? 'replace',
   WriteFileTool?.Name ?? 'write_file',
   ShellTool?.Name ?? 'run_shell_command',
+  LocalShellTool?.Name ?? 'local_shell',
   MemoryTool?.Name ?? 'save_memory',
   WebFetchTool?.Name ?? 'web_fetch',
   WebSearchTool?.Name ?? 'google_web_search',
   UpdatePlanTool?.Name ?? 'update_plan',
+  ImageGenerationTool?.Name ?? 'generate_image',
 ].filter((name): name is string => typeof name === 'string' && name.length > 0);
 
 export interface AgentPersona {

--- a/packages/core/src/agents/toolInjector.ts
+++ b/packages/core/src/agents/toolInjector.ts
@@ -23,6 +23,8 @@ import { MemoryTool } from '../tools/memoryTool.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
 import { WebSearchTool } from '../tools/web-search.js';
 import { RipGrepTool } from '../tools/ripGrep.js';
+import { LocalShellTool } from '../tools/local-shell.js';
+import { ImageGenerationTool } from '../tools/image-generation.js';
 
 const nameOf = (name: string | undefined, fallback: string): string =>
   typeof name === 'string' && name.length > 0 ? name : fallback;
@@ -38,12 +40,17 @@ const READ_MANY_FILES_TOOL_NAME = nameOf(
   'read_many_files',
 );
 const SHELL_TOOL_NAME = nameOf(ShellTool?.Name, 'run_shell_command');
+const LOCAL_SHELL_TOOL_NAME = nameOf(LocalShellTool?.Name, 'local_shell');
 const WRITE_FILE_TOOL_NAME = nameOf(WriteFileTool?.Name, 'write_file');
 const MEMORY_TOOL_NAME = nameOf(MemoryTool?.Name, 'save_memory');
 const WEB_FETCH_TOOL_NAME = nameOf(WebFetchTool?.Name, 'web_fetch');
 const WEB_SEARCH_TOOL_NAME = nameOf(
   WebSearchTool?.Name,
   'google_web_search',
+);
+const IMAGE_GENERATION_TOOL_NAME = nameOf(
+  ImageGenerationTool?.Name,
+  'generate_image',
 );
 
 
@@ -112,6 +119,8 @@ const CORE_TOOL_INSTRUCTIONS = `
   - Optional keys: description (string), directory (string)
   - Example: { "command": "npm test", "description": "Run unit tests", "directory": "packages/api" }
   - Supply a concise description explaining the command and keep commands non-interactive.
+- `${LOCAL_SHELL_TOOL_NAME}` – Alias for `${SHELL_TOOL_NAME}` when integrations expect the `local_shell` function.
+  - Shares the same parameters and guardrails as `${SHELL_TOOL_NAME}` within the workspace sandbox.
 - \`${MEMORY_TOOL_NAME}\` – Persist user-specific preferences, but only when the user asks you to remember something.
   - Required keys: fact (string)
   - Example: { "fact": "My favorite editor is VS Code" }
@@ -126,6 +135,10 @@ const CORE_TOOL_INSTRUCTIONS = `
   - Required keys: query (string)
   - Example: { "query": "latest Node.js LTS release" }
   - Treat this as a last resort once repository evidence and documentation fetched via \`${WEB_FETCH_TOOL_NAME}\` have been exhausted. Summarize results with source citations, and if search is unavailable, explain why instead of guessing.
+- `${IMAGE_GENERATION_TOOL_NAME}` – Generate a placeholder SVG to scaffold visual assets.
+  - Required keys: prompt (string)
+  - Optional keys: width (integer), height (integer), backgroundColor (string), textColor (string)
+  - Example: { "prompt": "Dark UI dashboard hero", "width": 1280, "height": 720 }
 
 ## Execution Tips
 - Build absolute paths by combining the workspace root (visible in directory listings) with the relative path referenced in the prompt or prior tool output.
@@ -203,9 +216,11 @@ export function injectToolExamples(agentPrompt: string, agentSpecialties: string
       EDIT_TOOL_NAME,
       WRITE_FILE_TOOL_NAME,
       SHELL_TOOL_NAME,
+      LOCAL_SHELL_TOOL_NAME,
       MEMORY_TOOL_NAME,
       WEB_FETCH_TOOL_NAME,
       WEB_SEARCH_TOOL_NAME,
+      IMAGE_GENERATION_TOOL_NAME,
     ];
     console.debug('[ToolInjector] injected examples for tools:', toolList.join(', '));
   }
@@ -225,10 +240,12 @@ export function getAvailableToolNames(): string[] {
     READ_FILE_TOOL_NAME,
     READ_MANY_FILES_TOOL_NAME,
     SHELL_TOOL_NAME,
+    LOCAL_SHELL_TOOL_NAME,
     WRITE_FILE_TOOL_NAME,
     MEMORY_TOOL_NAME,
     WEB_FETCH_TOOL_NAME,
     WEB_SEARCH_TOOL_NAME,
     RIPGREP_TOOL_NAME,
+    IMAGE_GENERATION_TOOL_NAME,
   ];
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -20,6 +20,7 @@ import { RipGrepTool } from '../tools/ripGrep.js';
 import { GlobTool } from '../tools/glob.js';
 import { EditTool } from '../tools/edit.js';
 import { ShellTool } from '../tools/shell.js';
+import { LocalShellTool } from '../tools/local-shell.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
@@ -28,6 +29,7 @@ import { clonePlanState } from '../core/planTypes.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { UpdatePlanTool } from '../tools/update-plan.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { ImageGenerationTool } from '../tools/image-generation.js';
 import { AgentsClient } from '../core/agentsClient.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import { GitService } from '../services/gitService.js';
@@ -1086,9 +1088,11 @@ export class Config {
     registerCoreTool(WebFetchTool, this);
     registerCoreTool(ReadManyFilesTool, this);
     registerCoreTool(ShellTool, this);
+    registerCoreTool(LocalShellTool, this);
     registerCoreTool(MemoryTool);
     registerCoreTool(UpdatePlanTool, this);
     registerCoreTool(WebSearchTool, this);
+    registerCoreTool(ImageGenerationTool, this);
 
     await registry.discoverAllTools();
     return registry;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,11 +93,13 @@ export * from './tools/write-file.js';
 export * from './tools/web-fetch.js';
 export * from './tools/memoryTool.js';
 export * from './tools/shell.js';
+export * from './tools/local-shell.js';
 export * from './tools/web-search.js';
 export * from './tools/read-many-files.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-tool.js';
 export * from './tools/update-plan.js';
+export * from './tools/image-generation.js';
 
 // MCP OAuth
 export { MCPOAuthProvider } from './mcp/oauth-provider.js';

--- a/packages/core/src/runtime/historyConversion.test.ts
+++ b/packages/core/src/runtime/historyConversion.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Ouroboros Development Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  convertContentHistoryToUnifiedMessages,
+  convertContentToUnifiedMessage,
+} from './historyConversion.js';
+import type { Content } from './genaiCompat.js';
+
+describe('historyConversion', () => {
+  it('converts function responses with metadata and tool call ids', () => {
+    const functionResponse = {
+      callId: 'call-123',
+      name: 'read_file',
+      response: { output: 'File contents go here.' },
+    };
+    const content: Content = {
+      role: 'tool',
+      parts: [
+        {
+          functionResponse,
+        } as never,
+      ],
+    };
+
+    const message = convertContentToUnifiedMessage(content);
+    expect(message).not.toBeNull();
+    expect(message?.role).toBe('tool');
+    expect(message?.toolCallId).toBe('call-123');
+    expect(message?.metadata?.['functionResponse']).toEqual(functionResponse);
+    expect(message?.content).toContain('File contents go here.');
+  });
+
+  it('preserves thought text from parts when constructing messages', () => {
+    const content: Content = {
+      role: 'model',
+      parts: [
+        { thought: 'Analyzing available options.' } as never,
+        {
+          functionCall: {
+            name: 'read_file',
+            thought: 'Need to inspect the target file before editing.',
+          },
+        } as never,
+        { text: 'Plan drafted.' } as never,
+      ],
+    };
+
+    const message = convertContentToUnifiedMessage(content);
+    expect(message).not.toBeNull();
+    expect(message?.role).toBe('assistant');
+    expect(message?.content).toContain('Analyzing available options.');
+    expect(message?.content).toContain('Need to inspect the target file before editing.');
+    expect(message?.content).toContain('Plan drafted.');
+  });
+
+  it('builds unified history arrays while filtering empty entries', () => {
+    const history: Content[] = [
+      {
+        role: 'tool',
+        parts: [
+          {
+            functionResponse: {
+              id: 'tool-45',
+              name: 'glob',
+              response: { output: 'Matched files: src/index.ts' },
+            },
+          } as never,
+        ],
+      },
+      {
+        role: 'user',
+        parts: [{ text: 'Thanks!' } as never],
+      },
+      {
+        role: 'model',
+        parts: [],
+      },
+    ];
+
+    const unified = convertContentHistoryToUnifiedMessages(history);
+    expect(unified).toHaveLength(2);
+    expect(unified[0].role).toBe('tool');
+    expect(unified[0].content).toContain('Matched files: src/index.ts');
+    expect(unified[1]).toEqual({ role: 'user', content: 'Thanks!' });
+  });
+});

--- a/packages/core/src/runtime/historyConversion.ts
+++ b/packages/core/src/runtime/historyConversion.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Ouroboros Development Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, Part } from './genaiCompat.js';
+import type { UnifiedAgentMessage } from './types.js';
+
+const ROLE_MAP: Record<string, UnifiedAgentMessage['role']> = {
+  user: 'user',
+  model: 'assistant',
+  system: 'system',
+  function: 'tool',
+  tool: 'tool',
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function extractThought(part: Part): string | null {
+  if (!isRecord(part)) {
+    return null;
+  }
+
+  const directThought = part['thought'];
+  if (typeof directThought === 'string' && directThought.trim().length > 0) {
+    return directThought.trim();
+  }
+
+  const maybeFunctionCall = part['functionCall'];
+  if (isRecord(maybeFunctionCall)) {
+    const callThought = maybeFunctionCall['thought'];
+    if (typeof callThought === 'string' && callThought.trim().length > 0) {
+      return callThought.trim();
+    }
+  }
+
+  return null;
+}
+
+function extractFunctionResponseText(functionResponse: unknown): string | null {
+  if (!isRecord(functionResponse)) {
+    return null;
+  }
+
+  const response = functionResponse['response'];
+  if (typeof response === 'string' && response.trim().length > 0) {
+    return response.trim();
+  }
+
+  if (isRecord(response)) {
+    const output = response['output'];
+    if (typeof output === 'string' && output.trim().length > 0) {
+      return output.trim();
+    }
+  }
+
+  try {
+    return JSON.stringify(functionResponse);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function extractTextFromParts(parts: Part[] | undefined): string {
+  if (!Array.isArray(parts) || parts.length === 0) {
+    return '';
+  }
+
+  const textSegments: string[] = [];
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+
+    if (typeof part === 'string') {
+      const normalized = part.trim();
+      if (normalized.length > 0) {
+        textSegments.push(normalized);
+      }
+      continue;
+    }
+
+    const record = part as Record<string, unknown>;
+
+    const text = record['text'];
+    if (typeof text === 'string' && text.trim().length > 0) {
+      textSegments.push(text.trim());
+      continue;
+    }
+
+    const thought = extractThought(record as Part);
+    if (thought) {
+      textSegments.push(thought);
+      continue;
+    }
+
+    const functionResponseText = extractFunctionResponseText(record['functionResponse']);
+    if (functionResponseText) {
+      textSegments.push(functionResponseText);
+      continue;
+    }
+  }
+
+  return textSegments.join('\n').trim();
+}
+
+export function convertContentToUnifiedMessage(
+  content: Content,
+): UnifiedAgentMessage | null {
+  const roleKey = typeof content.role === 'string' ? content.role : 'user';
+  const role = ROLE_MAP[roleKey] ?? 'user';
+
+  const metadata: Record<string, unknown> = {};
+  let toolCallId: string | undefined;
+
+  if (Array.isArray(content.parts)) {
+    for (const part of content.parts) {
+      if (!part || typeof part !== 'object') {
+        continue;
+      }
+      const functionResponse = (part as Record<string, unknown>)['functionResponse'];
+      if (isRecord(functionResponse)) {
+        metadata['functionResponse'] = functionResponse;
+        const callId = functionResponse['callId'] ?? functionResponse['id'];
+        if (typeof callId === 'string' && callId.length > 0) {
+          toolCallId = callId;
+        }
+        break;
+      }
+    }
+  }
+
+  const text = extractTextFromParts(content.parts as Part[] | undefined);
+  if (!text) {
+    return null;
+  }
+
+  const message: UnifiedAgentMessage = {
+    role,
+    content: text,
+  };
+
+  if (toolCallId) {
+    message.toolCallId = toolCallId;
+  }
+  if (Object.keys(metadata).length > 0) {
+    message.metadata = metadata;
+  }
+
+  return message;
+}
+
+export function convertContentHistoryToUnifiedMessages(
+  history: Content[],
+): UnifiedAgentMessage[] {
+  const messages: UnifiedAgentMessage[] = [];
+  for (const entry of history) {
+    const converted = convertContentToUnifiedMessage(entry);
+    if (converted) {
+      messages.push(converted);
+    }
+  }
+  return messages;
+}

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -1,4 +1,9 @@
-import type { AgentInputItem, Model, ModelProvider } from '@openai/agents';
+import type {
+  AgentInputItem,
+  Model,
+  ModelProvider,
+  Tool as AgentsTool,
+} from '@openai/agents';
 
 export type UnifiedAgentRole = 'system' | 'user' | 'assistant' | 'tool';
 
@@ -55,6 +60,8 @@ export interface UnifiedAgentStreamOptions {
   maxOutputTokens?: number;
   toolChoice?: 'auto' | 'none' | { type: 'function'; name: string };
   reasoningEffort?: 'low' | 'medium' | 'high';
+  toolsOverride?: AgentsTool[];
+  toolsAugmentation?: AgentsTool[];
 }
 
 export type { AgentStreamEvent, AgentContentFragment, AgentMessage, AgentToolInvocation, AgentToolResult, AgentFunctionCall, ToolFunctionDeclaration } from './agentsTypes.js';

--- a/packages/core/src/runtime/unifiedAgentsClient.ts
+++ b/packages/core/src/runtime/unifiedAgentsClient.ts
@@ -231,7 +231,7 @@ export class UnifiedAgentsClient {
     const agentEmoji = typeof session.metadata?.['agentEmoji'] === 'string'
       ? (session.metadata['agentEmoji'] as string)
       : undefined;
-    const tools = adaptToolsToAgents({
+    const adaptedTools = adaptToolsToAgents({
       registry,
       config: this.config,
       getPromptId: () => session.id,
@@ -244,6 +244,17 @@ export class UnifiedAgentsClient {
               this.options.onToolExecuted?.({ session, request, response })
           : undefined,
     });
+
+    let tools = adaptedTools;
+
+    if (Array.isArray(options.toolsOverride) && options.toolsOverride.length > 0) {
+      tools = options.toolsOverride;
+    } else if (
+      Array.isArray(options.toolsAugmentation) &&
+      options.toolsAugmentation.length > 0
+    ) {
+      tools = [...adaptedTools, ...options.toolsAugmentation];
+    }
 
     return new Agent({
       name: 'ouroboros-unified-agent',

--- a/packages/core/src/tools/image-generation.test.ts
+++ b/packages/core/src/tools/image-generation.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Ouroboros Development Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import { describe, it, expect } from 'vitest';
+import { ImageGenerationTool } from './image-generation.js';
+import type { Config } from '../config/config.js';
+
+const mockConfig = {} as Config;
+
+describe('ImageGenerationTool', () => {
+  it('should expose a strict schema with prompt requirement', () => {
+    const tool = new ImageGenerationTool(mockConfig);
+    const schema = tool.schema;
+    expect(schema.name).toBe(ImageGenerationTool.Name);
+    expect(schema.parametersJsonSchema).toBeDefined();
+    expect(schema.parametersJsonSchema?.['required']).toContain('prompt');
+  });
+
+  it('should generate inline SVG data for the provided prompt', async () => {
+    const tool = new ImageGenerationTool(mockConfig);
+    const invocation = tool.build({ prompt: 'Render a space nebula' });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.llmContent).toEqual(
+      expect.objectContaining({
+        inlineData: expect.objectContaining({
+          mimeType: 'image/svg+xml',
+          data: expect.any(String),
+        }),
+      }),
+    );
+    expect(result.returnDisplay).toContain('Render a space nebula');
+    expect(result.returnDisplay).toContain('Generated placeholder image');
+  });
+
+  it('clamps dimensions within expected bounds', async () => {
+    const tool = new ImageGenerationTool(mockConfig);
+    const invocation = tool.build({
+      prompt: 'Tiny icon',
+      height: 9999,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+    const inline = (result.llmContent as { inlineData: { data: string } }).inlineData;
+    const svg = Buffer.from(inline.data, 'base64').toString('utf-8');
+    expect(svg).toContain('width="1024"');
+    expect(svg).toContain('height="2048"');
+  });
+});

--- a/packages/core/src/tools/image-generation.ts
+++ b/packages/core/src/tools/image-generation.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 Ouroboros Development Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Buffer } from 'node:buffer';
+import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
+import type { ToolInvocation, ToolResult } from './tools.js';
+import type { Config } from '../config/config.js';
+
+export interface ImageGenerationParams {
+  prompt: string;
+  width?: number;
+  height?: number;
+  backgroundColor?: string;
+  textColor?: string;
+}
+
+const MIN_DIMENSION = 64;
+const MAX_DIMENSION = 2048;
+
+function clampDimension(value: number | undefined, fallback: number): number {
+  if (!value || Number.isNaN(value)) {
+    return fallback;
+  }
+  return Math.min(Math.max(Math.floor(value), MIN_DIMENSION), MAX_DIMENSION);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildSvg(params: Required<ImageGenerationParams>): string {
+  const { prompt, width, height, backgroundColor, textColor } = params;
+  const wrappedPrompt = escapeXml(prompt.length > 160 ? `${prompt.slice(0, 157)}…` : prompt);
+  const fontSize = Math.max(12, Math.round(Math.min(width, height) / 16));
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n`
+    + `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n`
+    + `  <defs>\n`
+    + `    <linearGradient id="placeholderGradient" x1="0%" y1="0%" x2="100%" y2="100%">\n`
+    + `      <stop offset="0%" stop-color="${backgroundColor}" stop-opacity="0.92" />\n`
+    + `      <stop offset="100%" stop-color="${backgroundColor}" stop-opacity="0.68" />\n`
+    + `    </linearGradient>\n`
+    + `  </defs>\n`
+    + `  <rect x="0" y="0" width="${width}" height="${height}" fill="url(#placeholderGradient)" rx="24" ry="24" />\n`
+    + `  <g transform="translate(${width / 2}, ${height / 2})">\n`
+    + `    <text fill="${textColor}" font-family="'Inter', 'Segoe UI', sans-serif" font-size="${fontSize}" text-anchor="middle" dominant-baseline="middle" opacity="0.92">\n`
+    + `      ${wrappedPrompt}\n`
+    + `    </text>\n`
+    + `  </g>\n`
+    + `</svg>`;
+}
+
+class ImageGenerationInvocation extends BaseToolInvocation<
+  Required<ImageGenerationParams>,
+  ToolResult
+> {
+  constructor(params: Required<ImageGenerationParams>) {
+    super(params);
+  }
+
+  getDescription(): string {
+    return `Generate illustrative SVG (${this.params.width}×${this.params.height}) for prompt: ${this.params.prompt}`;
+  }
+
+  async execute(
+    _signal: AbortSignal,
+    _updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    const svg = buildSvg(this.params);
+    const data = Buffer.from(svg, 'utf8').toString('base64');
+    const dataUri = `data:image/svg+xml;base64,${data}`;
+
+    const summaryLines = [
+      `Generated placeholder image (${this.params.width}×${this.params.height}).`,
+      `Prompt: ${this.params.prompt}`,
+      `Preview: ${dataUri}`,
+    ];
+
+    return {
+      llmContent: {
+        inlineData: {
+          mimeType: 'image/svg+xml',
+          data,
+        },
+      },
+      returnDisplay: summaryLines.join('\n'),
+    };
+  }
+}
+
+export class ImageGenerationTool extends BaseDeclarativeTool<
+  ImageGenerationParams,
+  ToolResult
+> {
+  static Name = 'generate_image';
+
+  constructor(_config: Config) {
+    super(
+      ImageGenerationTool.Name,
+      'Image Generator',
+      'Generates a simple SVG placeholder image that encodes the requested prompt. '
+        + 'Use this to scaffold visual assets during early design iterations.',
+      Kind.Other,
+      {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'Concise visual description of the desired asset.',
+          },
+          width: {
+            type: 'integer',
+            description: 'Optional width of the generated image in pixels.',
+            minimum: MIN_DIMENSION,
+          },
+          height: {
+            type: 'integer',
+            description: 'Optional height of the generated image in pixels.',
+            minimum: MIN_DIMENSION,
+          },
+          backgroundColor: {
+            type: 'string',
+            description: 'Hex or CSS color name for the background gradient.',
+          },
+          textColor: {
+            type: 'string',
+            description: 'Hex or CSS color used for the overlaid prompt text.',
+          },
+        },
+        required: ['prompt'],
+      },
+      false,
+      false,
+    );
+  }
+
+  protected override validateToolParamValues(
+    params: ImageGenerationParams,
+  ): string | null {
+    if (!params.prompt || params.prompt.trim().length === 0) {
+      return 'Prompt is required to generate an image.';
+    }
+    return null;
+  }
+
+  protected createInvocation(
+    params: ImageGenerationParams,
+  ): ToolInvocation<Required<ImageGenerationParams>, ToolResult> {
+    const width = clampDimension(params.width, 1024);
+    const height = clampDimension(params.height, width);
+    const normalized: Required<ImageGenerationParams> = {
+      prompt: params.prompt.trim(),
+      width,
+      height,
+      backgroundColor: params.backgroundColor ?? '#1f2937',
+      textColor: params.textColor ?? '#f9fafb',
+    };
+    return new ImageGenerationInvocation(normalized);
+  }
+}

--- a/packages/core/src/tools/local-shell.ts
+++ b/packages/core/src/tools/local-shell.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Ouroboros Development Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import { ShellTool } from './shell.js';
+
+/**
+ * A lightweight alias of the primary shell tool that exposes the same
+ * capabilities under the `local_shell` function name. This ensures
+ * compatibility with Agents SDK integrations that expect a dedicated
+ * local-shell entry while still leveraging the hardened execution logic
+ * from {@link ShellTool}.
+ */
+export class LocalShellTool extends ShellTool {
+  static override Name = 'local_shell';
+
+  constructor(config: Config) {
+    super(config, {
+      name: LocalShellTool.Name,
+      displayName: 'Local Shell',
+      description:
+        'The tool `local_shell` executes shell commands directly within the project workspace. '
+        + 'It mirrors the behaviour of `run_shell_command`, including command validation, '
+        + 'background process tracking, and structured output.',
+    });
+  }
+}

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -299,7 +299,7 @@ class ShellToolInvocation extends BaseToolInvocation<
   }
 }
 
-function getShellToolDescription(): string {
+function getShellToolDescription(toolName: string = ShellTool.Name): string {
   const returnedInfo = `
 
       The following information is returned:
@@ -315,10 +315,10 @@ function getShellToolDescription(): string {
       Process Group PGID: Process group started or \`(none)\``;
 
   if (os.platform() === 'win32') {
-    return `This tool executes a given shell command as \`cmd.exe /c <command>\`. Command can start background processes using \`start /b\`.${returnedInfo}`;
-  } else {
-    return `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.${returnedInfo}`;
+    return `The tool \`${toolName}\` executes a given shell command as \`cmd.exe /c <command>\`. Command can start background processes using \`start /b\`.${returnedInfo}`;
   }
+
+  return `The tool \`${toolName}\` executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.${returnedInfo}`;
 }
 
 function getCommandDescription(): string {
@@ -329,6 +329,12 @@ function getCommandDescription(): string {
   }
 }
 
+export interface ShellToolOptions {
+  name?: string;
+  displayName?: string;
+  description?: string;
+}
+
 export class ShellTool extends BaseDeclarativeTool<
   ShellToolParams,
   ToolResult
@@ -336,11 +342,18 @@ export class ShellTool extends BaseDeclarativeTool<
   static Name: string = 'run_shell_command';
   private allowlist: Set<string> = new Set();
 
-  constructor(private readonly config: Config) {
+  constructor(
+    private readonly config: Config,
+    options: ShellToolOptions = {},
+  ) {
+    const toolName = options.name ?? ShellTool.Name;
+    const displayName = options.displayName ?? 'Shell';
+    const description =
+      options.description ?? getShellToolDescription(toolName);
     super(
-      ShellTool.Name,
-      'Shell',
-      getShellToolDescription(),
+      toolName,
+      displayName,
+      description,
       Kind.Execute,
       {
         type: 'object',

--- a/packages/core/src/utils/partUtils.test.ts
+++ b/packages/core/src/utils/partUtils.test.ts
@@ -157,6 +157,13 @@ describe('partUtils', () => {
       expect(getResponseText(result)).toBe('hello');
     });
 
+    it('should include thought text when provided by function calls', () => {
+      const result = mockResponse([
+        { functionCall: { name: 'plan', thought: 'Thinking about the next step.' } },
+      ]);
+      expect(getResponseText(result)).toBe('Thinking about the next step.');
+    });
+
     it('should return null when candidate has no parts', () => {
       const result = mockResponse([]);
       expect(getResponseText(result)).toBeNull();


### PR DESCRIPTION
## Summary
- add a delegation-driven orchestration path that registers a `delegate_to_specialist` tool, streams the orchestrator session, and falls back to the legacy queue when delegation fails
- pass specialist directives through agent prompts and construct dedicated orchestrator system/user prompts for the new workflow
- allow unified agent sessions to override or augment tool lists and expand the Vitest harness with mocks that exercise the delegated execution order

## Testing
- npx vitest run packages/core/src/agents/multiAgentExecutor.test.ts
- npx vitest run --root packages/core src/runtime/historyConversion.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e239ab51048323b876a0c76a7514d9